### PR TITLE
Silverstripe v5 upgrade

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/framework": "^4.0"
+        "silverstripe/framework": "^4.0 || ^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",
@@ -21,5 +21,11 @@
         }
     },
     "minimum-stability": "dev",
-    "prefer-stable": true
+    "prefer-stable": true,
+    "config": {
+        "allow-plugins": {
+            "composer/installers": true,
+            "silverstripe/vendor-plugin": true
+        }
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "silverstripe/framework": "^4.0 || ^5.0"
+        "silverstripe/framework": "^5.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.5",

--- a/src/DockerLogHandler.php
+++ b/src/DockerLogHandler.php
@@ -47,8 +47,9 @@ class DockerLogHandler extends AbstractProcessingHandler
         if (!is_resource($this->stream)) {
             $this->stream = fopen("php://stdout", 'w');
         }
-        $record['source'] = 'silverstripe';
-        fwrite($this->stream, (string)$record['formatted']);
+        $record->extra['source'] = 'silverstripe';
+
+        fwrite($this->stream, (string)$record->formatted);
     }
 
     /**

--- a/src/DockerLogHandler.php
+++ b/src/DockerLogHandler.php
@@ -3,8 +3,10 @@
 namespace MadeCurious\DockerLogging;
 
 use Monolog\Formatter\JsonFormatter;
+use Monolog\Formatter\FormatterInterface;
 use Monolog\Handler\AbstractProcessingHandler;
 use Monolog\Logger;
+use Monolog\LogRecord;
 
 class DockerLogHandler extends AbstractProcessingHandler
 {
@@ -28,7 +30,7 @@ class DockerLogHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    public function close()
+    public function close(): void
     {
         if (is_resource($this->stream)) {
             fclose($this->stream);
@@ -40,7 +42,7 @@ class DockerLogHandler extends AbstractProcessingHandler
     /**
      * {@inheritdoc}
      */
-    protected function write(array $record)
+    protected function write(LogRecord $record): void
     {
         if (!is_resource($this->stream)) {
             $this->stream = fopen("php://stdout", 'w');
@@ -52,7 +54,7 @@ class DockerLogHandler extends AbstractProcessingHandler
     /**
      * {@inheritDoc}
      */
-    protected function getDefaultFormatter()
+    protected function getDefaultFormatter(): FormatterInterface
     {
         return new JsonFormatter();
     }

--- a/src/DockerLogProcessor.php
+++ b/src/DockerLogProcessor.php
@@ -3,10 +3,11 @@
 namespace MadeCurious\DockerLogging;
 
 use Monolog\Processor\ProcessorInterface;
+use Monolog\LogRecord;
 
 class DockerLogProcessor implements ProcessorInterface
 {
-    public function __invoke(array $record)
+    public function __invoke(LogRecord $record)
     {
         # Add silverstripe and ISO86001 timestamp to all requests
         $now = new \DateTime("now", new \DateTimeZone("UTC"));

--- a/src/DockerLogProcessor.php
+++ b/src/DockerLogProcessor.php
@@ -11,16 +11,16 @@ class DockerLogProcessor implements ProcessorInterface
     {
         # Add silverstripe and ISO86001 timestamp to all requests
         $now = new \DateTime("now", new \DateTimeZone("UTC"));
-        $record = ['source' => 'silverstripe', 'timestamp' => $now->format('c')] + $record;
-        unset($record['datetime']);
+        $record->extra['source'] = 'silverstripe';
+        $record->extra['timestamp'] = $now->format('c');
 
         # If we're getting a request ID from nginx, include this
         if(isset($_SERVER['HTTP_X_REQUEST_ID'])) {
-            $record['request_id'] = $_SERVER['HTTP_X_REQUEST_ID'];
+            $record->extra['request_id'] = $_SERVER['HTTP_X_REQUEST_ID'];
         }
 
         # Set severity to harmonise with other sources
-        $record['severity'] = strtolower($record['level_name']);
+        $record->extra['severity'] = strtolower($record->level->name);
 
         return $record;
     }


### PR DESCRIPTION
Updates this module to be compatible with silverstripe 5. 

Due to changes in Monolog's LogRecord properties the output of the logger has changed. 

Old
```json
{
  "source": "silverstripe",
  "timestamp": "2025-03-26T01:56:37+00:00",
  "message": "<message here>",
  "context": [],
  "level": 400,
  "level_name": "ERROR",
  "channel": "error-log",
  "extra": [],
  "severity": "error"
}
```
vs 

```json
{
  "message": "<message here>",
  "context": {},
  "level": 400,
  "level_name": "ERROR",
  "channel": "error-log",
  "datetime": "2025-03-26T15:02:37.006753+13:00",
  "extra": {
    "source": "silverstripe",
    "timestamp": "2025-03-26T02:02:37+00:00",
    "severity": "error"
  }
}
```
